### PR TITLE
feat: added immediate termination handling for rate limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@book000/eslint-config": "1.14.61",
     "@book000/node-utils": "1.24.228",
-    "@book000/pixivts": "0.48.95",
+    "@book000/pixivts": "0.51.1",
     "@types/node": "24.13.2",
     "eslint": "10.4.1",
     "eslint-config-standard": "17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.24.228
         version: 1.24.228
       '@book000/pixivts':
-        specifier: 0.48.95
-        version: 0.48.95(@types/node@24.13.2)(typescript@6.0.3)
+        specifier: 0.51.1
+        version: 0.51.1(@types/node@24.13.2)(typescript@6.0.3)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -53,8 +53,8 @@ packages:
   '@book000/node-utils@1.24.228':
     resolution: {integrity: sha512-9qgrK7mEQG1VA5QOfrGB0vU+dI1Y8Kcc3g6ha/a+n43oHVYA6FHN1sgIpyYzMfbkUREOTTgP3WhhYjSOWktrCw==}
 
-  '@book000/pixivts@0.48.95':
-    resolution: {integrity: sha512-mmpS6IGDTAGPncHt5Y/81t/fZI2OubVdWg0stjt/Yj50EME7vxqhU7zLt5iR/jkSsZAv7WuGXL/m5pLv7NTBMA==}
+  '@book000/pixivts@0.51.1':
+    resolution: {integrity: sha512-a7ouFAxgLvMU0JpZ9toe3Zgf2X7j2qMhIth3W20npGPk+tDY7llcOBf8fdxTGIkrEiy0lKMfvo1pfwsBZM12JA==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1757,7 +1757,7 @@ snapshots:
       winston: 3.19.0
       winston-daily-rotate-file: 5.0.0(winston@3.19.0)
 
-  '@book000/pixivts@0.48.95(@types/node@24.13.2)(typescript@6.0.3)':
+  '@book000/pixivts@0.51.1(@types/node@24.13.2)(typescript@6.0.3)':
     dependencies:
       '@types/qs': 6.15.1
       mysql2: 3.22.5(@types/node@24.13.2)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { BookmarkRestrict, Pixiv } from '@book000/pixivts'
+import { BookmarkRestrict, Pixiv, PixivRateLimitError } from '@book000/pixivts'
 import { Logger } from '@book000/node-utils'
 import fs from 'node:fs'
 
@@ -81,62 +81,66 @@ async function processIllusts(
 
   let maxBookmarkId: number | undefined
 
-  while (true) {
-    const publicBookmarkIllusts = await pixiv.userBookmarksIllust({
-      userId: Number(pixiv.userId),
-      restrict: BookmarkRestrict.PUBLIC,
-      maxBookmarkId,
-    })
-    if (publicBookmarkIllusts.status !== 200) {
-      logger.error(
-        `🚨 Failed to get public bookmark illusts: ${publicBookmarkIllusts.status}`
-      )
-      logger.error(JSON.stringify(publicBookmarkIllusts.data))
-      process.exitCode = 1
-      return
-    }
-
-    const illusts = publicBookmarkIllusts.data.illusts
-    logger.info(`🖼️ Public illust bookmarks: ${illusts.length}`)
-    for (const illust of illusts) {
-      logger.info(`🖼️ Illust: ${illust.title} (${illust.id})`)
-
-      const result = await pixiv.illustBookmarkAdd({
-        illustId: illust.id,
-        restrict: BookmarkRestrict.PRIVATE,
+  try {
+    while (true) {
+      const publicBookmarkIllusts = await pixiv.userBookmarksIllust({
+        userId: Number(pixiv.userId),
+        restrict: BookmarkRestrict.PUBLIC,
+        maxBookmarkId,
       })
-
-      if (result.status === 404) {
-        // If the illust is not found, skip it
-        logger.error(`🚨 Illust not found: ${illust.id}`)
-        if (isDeleteBookmarkForDeleted) {
-          logger.info(`🚨 Deleting bookmark: ${illust.id}`)
-          await pixiv.illustBookmarkDelete({
-            illustId: illust.id.toString(),
-          })
-        }
-        continue
-      } else if (result.status === 403) {
-        // Rate limit exceeded
-        logger.error(`🚨 Rate limit exceeded: ${result.status}`)
-        break
-      } else if (result.status !== 200) {
-        // If the request failed, log the error and continue
-        logger.error(`🚨 Failed to add bookmark: ${result.status}`)
-        logger.error(JSON.stringify(result.data))
+      if (publicBookmarkIllusts.status !== 200) {
+        logger.error(
+          `🚨 Failed to get public bookmark illusts: ${publicBookmarkIllusts.status}`
+        )
+        logger.error(JSON.stringify(publicBookmarkIllusts.data))
         process.exitCode = 1
-        continue
+        return
       }
+
+      const illusts = publicBookmarkIllusts.data.illusts
+      logger.info(`🖼️ Public illust bookmarks: ${illusts.length}`)
+      for (const illust of illusts) {
+        logger.info(`🖼️ Illust: ${illust.title} (${illust.id})`)
+
+        const result = await pixiv.illustBookmarkAdd({
+          illustId: illust.id,
+          restrict: BookmarkRestrict.PRIVATE,
+        })
+
+        if (result.status === 404) {
+          // If the illust is not found, skip it
+          logger.error(`🚨 Illust not found: ${illust.id}`)
+          if (isDeleteBookmarkForDeleted) {
+            logger.info(`🚨 Deleting bookmark: ${illust.id}`)
+            await pixiv.illustBookmarkDelete({
+              illustId: illust.id.toString(),
+            })
+          }
+          continue
+        } else if (result.status !== 200) {
+          // If the request failed, log the error and continue
+          logger.error(`🚨 Failed to add bookmark: ${result.status}`)
+          logger.error(JSON.stringify(result.data))
+          process.exitCode = 1
+          continue
+        }
+      }
+
+      if (!publicBookmarkIllusts.data.next_url) {
+        break
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      const qs = Pixiv.parseQueryString(publicBookmarkIllusts.data.next_url)
+      maxBookmarkId = Number(qs.max_bookmark_id)
+    }
+  } catch (error) {
+    if (error instanceof PixivRateLimitError) {
+      logger.error('🚨 Rate limit exceeded')
     }
 
-    if (!publicBookmarkIllusts.data.next_url) {
-      break
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
-    const qs = Pixiv.parseQueryString(publicBookmarkIllusts.data.next_url)
-    maxBookmarkId = Number(qs.max_bookmark_id)
+    throw error
   }
 }
 
@@ -148,61 +152,65 @@ async function processNovels(
 
   let maxBookmarkId: number | undefined
 
-  while (true) {
-    const publicBookmarkNovels = await pixiv.userBookmarksNovel({
-      userId: Number(pixiv.userId),
-      restrict: BookmarkRestrict.PUBLIC,
-      maxBookmarkId,
-    })
-    if (publicBookmarkNovels.status !== 200) {
-      logger.error(
-        `🚨 Failed to get public bookmark novels: ${publicBookmarkNovels.status}`
-      )
-      logger.error(JSON.stringify(publicBookmarkNovels.data))
-      process.exitCode = 1
-      return
-    }
-
-    const novels = publicBookmarkNovels.data.novels
-    logger.info(`📕 Public novel bookmarks: ${novels.length}`)
-    for (const novel of novels) {
-      logger.info(`📕 Novel: ${novel.title} (${novel.id})`)
-
-      const result = await pixiv.novelBookmarkAdd({
-        novelId: novel.id.toString(),
-        restrict: BookmarkRestrict.PRIVATE,
+  try {
+    while (true) {
+      const publicBookmarkNovels = await pixiv.userBookmarksNovel({
+        userId: Number(pixiv.userId),
+        restrict: BookmarkRestrict.PUBLIC,
+        maxBookmarkId,
       })
-      if (result.status === 404) {
-        // If the novel is not found, skip it
-        logger.error(`🚨 Novel not found: ${novel.id}`)
-        if (isDeleteBookmarkForDeleted) {
-          logger.info(`🚨 Deleting bookmark: ${novel.id}`)
-          await pixiv.novelBookmarkDelete({
-            novelId: novel.id.toString(),
-          })
-        }
-        continue
-      } else if (result.status === 403) {
-        // Rate limit exceeded
-        logger.error(`🚨 Rate limit exceeded: ${result.status}`)
-        break
-      } else if (result.status !== 200) {
-        // If the request failed, log the error and continue
-        logger.error(`🚨 Failed to add bookmark: ${result.status}`)
-        logger.error(JSON.stringify(result.data))
+      if (publicBookmarkNovels.status !== 200) {
+        logger.error(
+          `🚨 Failed to get public bookmark novels: ${publicBookmarkNovels.status}`
+        )
+        logger.error(JSON.stringify(publicBookmarkNovels.data))
         process.exitCode = 1
-        continue
+        return
       }
+
+      const novels = publicBookmarkNovels.data.novels
+      logger.info(`📕 Public novel bookmarks: ${novels.length}`)
+      for (const novel of novels) {
+        logger.info(`📕 Novel: ${novel.title} (${novel.id})`)
+
+        const result = await pixiv.novelBookmarkAdd({
+          novelId: novel.id.toString(),
+          restrict: BookmarkRestrict.PRIVATE,
+        })
+        if (result.status === 404) {
+          // If the novel is not found, skip it
+          logger.error(`🚨 Novel not found: ${novel.id}`)
+          if (isDeleteBookmarkForDeleted) {
+            logger.info(`🚨 Deleting bookmark: ${novel.id}`)
+            await pixiv.novelBookmarkDelete({
+              novelId: novel.id.toString(),
+            })
+          }
+          continue
+        } else if (result.status !== 200) {
+          // If the request failed, log the error and continue
+          logger.error(`🚨 Failed to add bookmark: ${result.status}`)
+          logger.error(JSON.stringify(result.data))
+          process.exitCode = 1
+          continue
+        }
+      }
+
+      if (!publicBookmarkNovels.data.next_url) {
+        break
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      const qs = Pixiv.parseQueryString(publicBookmarkNovels.data.next_url)
+      maxBookmarkId = Number(qs.max_bookmark_id)
+    }
+  } catch (error) {
+    if (error instanceof PixivRateLimitError) {
+      logger.error('🚨 Rate limit exceeded')
     }
 
-    if (!publicBookmarkNovels.data.next_url) {
-      break
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
-    const qs = Pixiv.parseQueryString(publicBookmarkNovels.data.next_url)
-    maxBookmarkId = Number(qs.max_bookmark_id)
+    throw error
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,13 +234,15 @@ async function main() {
     )
   }
 
-  // Illusts
-  await processIllusts(pixiv, isDeleteBookmarkForDeleted)
+  try {
+    // Illusts
+    await processIllusts(pixiv, isDeleteBookmarkForDeleted)
 
-  // Novels
-  await processNovels(pixiv, isDeleteBookmarkForDeleted)
-
-  await pixiv.close()
+    // Novels
+    await processNovels(pixiv, isDeleteBookmarkForDeleted)
+  } finally {
+    await pixiv.close()
+  }
 }
 
 ;(async () => {


### PR DESCRIPTION
- close #3025 

If a rate limit is encountered, the loop for both illustrations and novels will be terminated immediately.

While an account-level rate limit may return a 403 error, a 403 error does not necessarily indicate a rate limit, so it has been excluded from this update.

This implementation is based on the rate limit handling introduced in [pixivts v0.49.0 through v0.51.1](https://github.com/book000/pixivts/releases).