### PR TITLE
docs: switch project language to English

### DIFF
--- a/.github/workflows/check-pr-language.yml
+++ b/.github/workflows/check-pr-language.yml
@@ -1,0 +1,29 @@
+name: Check PR language
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+# Disable all default permissions; grant only what each job needs.
+permissions: {}
+
+jobs:
+  check-pr-language:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🟢 Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
+      - name: 🔤 Check PR language
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-pr-language.mjs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
-# 任意のレジストリに Docker image を公開orビルドする。
-# プルリクの作成・更新時に動作する。
+# Publish or build a Docker image to an arbitrary registry.
+# Runs when a pull request is created or updated.
 
 name: Docker
 
@@ -24,8 +24,8 @@ on:
       - closed
 
 concurrency:
-  # pull_request と pull_request_target が同一グループになると互いをキャンセルしてしまうため
-  # event_name を含めることで両イベントのキャンセルを独立させる
+  # If pull_request and pull_request_target share the same group, they would cancel each other,
+  # so include event_name to make the cancellation of each event independent
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -33,7 +33,7 @@ jobs:
   post-approval-request:
     name: Post approval request
     runs-on: ubuntu-latest
-    # フォーク PR のときのみ承認リクエストを投稿する（closed は不要）
+    # Only post an approval request for fork PRs (not needed for closed)
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'closed'
     continue-on-error: true
     permissions:
@@ -46,7 +46,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
-          body-includes: Environment 承認待ち
+          body-includes: Waiting for environment approval
 
       - name: Post or update approval request comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
@@ -55,19 +55,19 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
           body: |
-            ## Environment 承認待ち
+            ## Waiting for environment approval
 
-            この PR のビルドを実行するには、Environment `fork-pr-build` の承認が必要です。
+            To run the build for this PR, the `fork-pr-build` environment must be approved.
 
-            [Actions run を確認して承認してください](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
+            [Check and approve the Actions run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
 
   approval-gate:
     name: Approval gate
     runs-on: ubuntu-latest
     needs: post-approval-request
-    # post-approval-request の結果に関わらず常に実行する
+    # Always run regardless of the post-approval-request result
     if: always()
-    # フォーク PR かつ closed でない場合のみ Environment で手動承認が必要
+    # Manual environment approval is only required for fork PRs that are not closed
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'closed' && 'fork-pr-build' || '' }}
     permissions: {}
     steps:
@@ -89,4 +89,3 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/nodejs-ci-pnpm.yml
+++ b/.github/workflows/nodejs-ci-pnpm.yml
@@ -1,4 +1,4 @@
-# Node.js でビルド・テストを実行する。バージョンは .node-version に記載されているものを利用する
+# Build and test with Node.js. Use the version specified in .node-version
 
 name: Node CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# Claude Code Working Guidelines
+
+## Purpose
+
+This document defines the policies and rules for Claude Code (an AI coding assistant) when working on the pixiv-public-to-private project.
+
+## Project Overview
+
+- Purpose: changes all illustrations and novels publicly bookmarked on pixiv to private bookmarks
+- Main features:
+  - Fetches the public bookmark list (illusts and novels) via the pixiv API
+  - Changes each bookmark's visibility from public to private
+  - Optionally removes bookmarks for items that have been deleted
+  - Runs continuously in a loop inside a Docker container (`entrypoint.sh`)
+
+## Important Rules
+
+- Project language: English is the primary language for all project artifacts (code, comments, commit messages, PR titles/bodies, and documentation). The only exception is direct conversation with Claude Code itself, which follows the user's personal/global instructions.
+- Code comments: English
+- Error messages: English
+- A CI check (`.github/workflows/check-pr-language.yml`) fails the PR if the PR title or body is 80% or more Japanese
+
+## Environment Rules
+
+- Commit messages: follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+  - `<type>(<scope>): <description>` format
+  - `<description>` is written in English
+- Branch naming: follow [Conventional Branch](https://conventional-branch.github.io)
+  - `<type>/<description>` format
+  - Use the short form of `<type>` (feat, fix)
+- When researching a GitHub repository, clone it into a temporary directory and search there
+- Do not add commits or updates to existing Renovate-created pull requests
+
+## Code Change Rules
+
+- Never enable `skipLibCheck` in a TypeScript project to work around type errors
+- Add and update docstrings (JSDoc) for functions, written in English
+
+## Development Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run the application
+pnpm start
+
+# Run the application with auto-reload
+pnpm dev
+
+# Lint check (runs prettier, eslint, tsc in order)
+pnpm lint
+
+# Lint fix (runs prettier, eslint in order)
+pnpm fix
+```
+
+## Architecture and Key Files
+
+- `src/main.ts`: entry point. Authenticates with pixiv, then converts public illust/novel bookmarks to private
+- `entrypoint.sh`: Docker entrypoint that runs `pnpm start` in a loop with a 10-minute interval
+- `Dockerfile`: builds the production image
+- `compose.yaml`: example Docker Compose configuration
+
+## Work Checklist
+
+### Before New Work
+
+1. Thoroughly explore and understand the project
+2. Verify the working branch is appropriate — not a branch with a closed PR
+3. Verify it is a new branch based on the latest remote branch
+4. Verify that closed/unnecessary branches have been deleted
+5. Install dependencies with `pnpm install`
+
+### Before Commit/Push
+
+1. Commit message follows Conventional Commits (`<description>` in English)
+2. No sensitive information in the commit
+3. `pnpm lint` runs without errors
+4. Verify the change works as expected
+
+### Before Creating a PR
+
+1. The user has requested that a PR be created
+2. No sensitive information in the commit
+3. No risk of conflicts
+4. Run `/code-review:code-review` and address all findings with a score of 50 or higher
+
+### After Creating a PR
+
+1. Confirm no conflicts have occurred
+2. Update the PR body to reflect only the current state of the branch, in English, without including the update history of this PR
+3. Wait for GitHub Actions CI with `gh pr checks <PR ID> --watch` and confirm it does not fail
+4. Request a review from GitHub Copilot and respond to its comments
+5. Run `/code-review:code-review` to perform a code review. Address all findings with a score of 50 or higher
+
+## Repository-Specific Notes
+
+- The package manager is pnpm (version pinned in `package.json`)
+- The Node.js version is managed via the `.node-version` file
+- Renovate is enabled for automatic dependency updates

--- a/scripts/check-pr-language.mjs
+++ b/scripts/check-pr-language.mjs
@@ -1,0 +1,76 @@
+// Checks whether a PR title/body is mostly written in Japanese.
+// Dependency-free Node.js ESM script intended to be run from CI via
+// `pull_request_target` (see .github/workflows/check-pr-language.yml).
+
+// Threshold (inclusive) above which the text is considered "mostly Japanese".
+const JAPANESE_RATIO_THRESHOLD = 0.8
+
+// Hiragana, katakana, and CJK Unified Ideographs (incl. extension A).
+const JAPANESE_PATTERN = /[぀-ゟ゠-ヿ㐀-䶿一-鿿]/gu
+// Latin letters and digits.
+const LATIN_PATTERN = /[A-Za-z0-9]/gu
+
+/**
+ * Calculates the ratio of Japanese characters to the total number of
+ * Japanese and Latin alphanumeric characters in the given text.
+ *
+ * @param text - Text to inspect
+ * @returns A ratio between 0 and 1. Returns 0 if the text contains neither
+ *   Japanese nor Latin alphanumeric characters.
+ */
+function calculateJapaneseRatio(text) {
+  const japaneseCount = (text.match(JAPANESE_PATTERN) ?? []).length
+  const latinCount = (text.match(LATIN_PATTERN) ?? []).length
+  const total = japaneseCount + latinCount
+
+  if (total === 0) {
+    return 0
+  }
+
+  return japaneseCount / total
+}
+
+/**
+ * Checks the PR title and body against {@link JAPANESE_RATIO_THRESHOLD}.
+ *
+ * The body is skipped if it is empty (or only whitespace).
+ *
+ * @param title - PR title
+ * @param body - PR body (may be `null`/`undefined`/empty)
+ * @returns An array of human-readable failure messages. Empty if both the
+ *   title and body pass the check.
+ */
+function checkPullRequestLanguage(title, body) {
+  const failures = []
+
+  const titleRatio = calculateJapaneseRatio(title ?? '')
+  if (titleRatio >= JAPANESE_RATIO_THRESHOLD) {
+    failures.push(
+      `PR title appears to be mostly Japanese (Japanese ratio: ${titleRatio.toFixed(2)}). Please write the PR title in English.`
+    )
+  }
+
+  const trimmedBody = (body ?? '').trim()
+  if (trimmedBody.length > 0) {
+    const bodyRatio = calculateJapaneseRatio(trimmedBody)
+    if (bodyRatio >= JAPANESE_RATIO_THRESHOLD) {
+      failures.push(
+        `PR body appears to be mostly Japanese (Japanese ratio: ${bodyRatio.toFixed(2)}). Please write the PR body in English.`
+      )
+    }
+  }
+
+  return failures
+}
+
+const title = process.env.PR_TITLE ?? ''
+const body = process.env.PR_BODY ?? ''
+
+const failures = checkPullRequestLanguage(title, body)
+for (const failure of failures) {
+  console.error(failure)
+}
+
+if (failures.length > 0) {
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary

Implements #3036.

- Translated the remaining Japanese comments and strings in `.github/workflows/docker.yml` and `.github/workflows/nodejs-ci-pnpm.yml` into English (`src/main.ts` and `README.md` were already in English).
- Added `CLAUDE.md` documenting the project language policy: English is the primary language for code, comments, commit messages, PR titles/bodies, and documentation (Claude Code conversation remains the user's choice).
- Added `.github/workflows/check-pr-language.yml` and `scripts/check-pr-language.mjs`, which fail the PR check if the PR title or body is 80% or more Japanese (Japanese character ratio), following the same approach as book000/pixivts#1630.

## Verification

- `pnpm lint` passes
- `grep -rPn '[\x{3000}-\x{9FFF}\x{FF00}-\x{FFEF}]'` over the repo shows no remaining Japanese outside the new check script's regex pattern itself
- `node scripts/check-pr-language.mjs` verified locally against English and Japanese title/body examples