### PR TITLE
chore: refresh CLAUDE.md and add Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ Guidance for GitHub Copilot when reviewing pull requests in this repository. Thi
 ## Security
 
 - The pixiv refresh/access token lives in the token file (default `data/token.json`). Never hardcode tokens, and flag any change that logs token values or commits real credentials.
-- Token file paths and secrets come from the environment (`PIXIV_TOKEN_PATH`, `DELETE_BOOKMARK_FOR_DELETED_ITEMS`); do not introduce hardcoded alternatives.
+- Configuration comes from environment variables — the token file path (`PIXIV_TOKEN_PATH`) and the deleted-item behavior flag (`DELETE_BOOKMARK_FOR_DELETED_ITEMS`); do not introduce hardcoded alternatives.
 
 ## Known patterns — do not flag
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Copilot Code Review Instructions
+
+Guidance for GitHub Copilot when reviewing pull requests in this repository. This is a TypeScript (Node.js, ESM) app that converts public pixiv bookmarks/followings to private, running on a loop inside Docker.
+
+## Language
+
+- All PR titles, PR bodies, code, comments, and JSDoc must be in English.
+- The `check-pr-language` workflow fails a PR whose title or body is 80% or more Japanese. Flag non-English PR titles/bodies.
+
+## Conventions enforced by tooling (do not re-flag as style opinions)
+
+- Formatting is enforced by Prettier (`.prettierrc.yml`): no semicolons, single quotes, `printWidth` 80, `trailingComma: es5`, LF line endings. Do not raise findings that Prettier already normalizes.
+- Linting uses `@book000/eslint-config` via `eslint.config.mjs`. TypeScript runs under `strict` with `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, and `noFallthroughCasesInSwitch`.
+- Commit messages follow Conventional Commits with an English description.
+
+## Review focus
+
+- Error handling: the codebase reports failures by setting `process.exitCode = 1` and continuing, rather than throwing, so that one failing converter does not abort the others (see `src/main.ts` and `BaseConverter.run`). Preserve this pattern; flag changes that swallow errors silently or that let one converter's failure crash the whole run.
+- `PixivRateLimitExceededError` is intentionally re-thrown out of `BaseConverter.run` and handled in `main` to stop the run early. Do not "fix" this by catching and continuing.
+- New converters must extend `BaseConverter` and implement all abstract members; verify the `itemTypeName` matches the `ENABLE_<ITEM_TYPE>_CONVERTER` env-var convention.
+- Public functions and classes should carry English JSDoc, consistent with the existing code.
+- Never enable `skipLibCheck` in `tsconfig.json` to work around type errors.
+
+## Security
+
+- The pixiv refresh/access token lives in the token file (default `data/token.json`). Never hardcode tokens, and flag any change that logs token values or commits real credentials.
+- Token file paths and secrets come from the environment (`PIXIV_TOKEN_PATH`, `DELETE_BOOKMARK_FOR_DELETED_ITEMS`); do not introduce hardcoded alternatives.
+
+## Known patterns — do not flag
+
+- Emoji prefixes in log messages (e.g. `🚨`, `📝`, `🗑️`) are an intentional project convention.
+- Setting `process.exitCode = 1` instead of calling `process.exit()` is intentional (lets the current loop iteration finish cleanly).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,13 @@ This document defines the policies and rules for Claude Code (an AI coding assis
 
 ## Project Overview
 
-- Purpose: changes all illustrations and novels publicly bookmarked on pixiv to private bookmarks
+- Purpose: changes items publicly bookmarked/followed on pixiv (illust bookmarks, novel bookmarks, and followings) to private
 - Main features:
-  - Fetches the public bookmark list (illusts and novels) via the pixiv API
-  - Changes each bookmark's visibility from public to private
-  - Optionally removes bookmarks for items that have been deleted
+  - Fetches the public lists (illust bookmarks, novel bookmarks, followings) via the pixiv API
+  - Changes each item's visibility from public to private
+  - Optionally removes bookmarks/followings for items that have been deleted
   - Runs continuously in a loop inside a Docker container (`entrypoint.sh`)
+- Each item type is handled by a converter under `src/converters/` extending `BaseConverter`. A converter can be toggled via the `ENABLE_<ITEM_TYPE>_CONVERTER` environment variable (e.g. `ENABLE_ILLUST_BOOKMARKS_CONVERTER`); when unset, the converter's own default applies
 
 ## Important Rules
 
@@ -57,7 +58,9 @@ pnpm fix
 
 ## Architecture and Key Files
 
-- `src/main.ts`: entry point. Authenticates with pixiv, then converts public illust/novel bookmarks to private
+- `src/main.ts`: entry point. Authenticates with pixiv, then runs each converter in sequence
+- `src/converters/base.ts`: `BaseConverter` abstract class shared by all converters (pagination, per-item conversion, deleted-item handling, env-var enable check)
+- `src/converters/`: concrete converters — `illust-bookmarks.ts`, `novel-bookmarks.ts`, `following.ts`
 - `entrypoint.sh`: Docker entrypoint that runs `pnpm start` in a loop with a 10-minute interval
 - `Dockerfile`: builds the production image
 - `compose.yaml`: example Docker Compose configuration


### PR DESCRIPTION
## Summary

Refreshes the agent-facing documentation so it matches the current codebase, and adds a dedicated Copilot code-review instruction file.

## Changes

### `CLAUDE.md`
- Project Overview now reflects that the app converts illust bookmarks, novel bookmarks, **and followings** (previously only illust/novel bookmarks).
- Documents the converter architecture: each item type is handled by a converter under `src/converters/` extending `BaseConverter`, toggleable via the `ENABLE_<ITEM_TYPE>_CONVERTER` environment variable (falling back to each converter's own default when unset).
- Architecture section updated: `src/main.ts` runs each converter in sequence, and `src/converters/base.ts` / concrete converters (`illust-bookmarks.ts`, `novel-bookmarks.ts`, `following.ts`) are now listed.

### `.github/copilot-instructions.md` (new)
- Review-focused guidance for GitHub Copilot (distinct from `CLAUDE.md`, not a duplicate).
- Language policy and the `check-pr-language` workflow (fails a PR whose title/body is 80%+ Japanese).
- Tooling already enforced by Prettier / ESLint / `tsc` (so Copilot does not re-flag them as style opinions).
- Repository-specific review focus: the `process.exitCode = 1`-and-continue error pattern, the intentional re-throw of `PixivRateLimitExceededError`, the `BaseConverter` extension + `ENABLE_<ITEM_TYPE>_CONVERTER` naming convention, and token/security notes.

## Notes
- No files were deleted: this repository has no `AGENTS.md` / `GEMINI.md` / `.gemini` / `.codex`, so there was nothing to consolidate away.
- The env-var description in the Copilot security notes was reworded so the behavior flag `DELETE_BOOKMARK_FOR_DELETED_ITEMS` is no longer grouped under "secrets".
