### PR TITLE
chore: add .worktreeinclude for local secrets and data directory

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+data/token.json
+data/


### PR DESCRIPTION
## Summary

Adds a `.worktreeinclude` file listing gitignored paths that should remain available across `git worktree` checkouts, since they are required to run the app locally but are not tracked in git.

## Patterns added

```
.env
data/token.json
data/
```

## Evidence

- `compose.yaml`: `env_file: - .env` and `volumes: - ./data:/data` mount a local directory.
- `.gitignore` includes `.env`, `.env.local`, `.env.*.local`, and `data/`.
- README.md "Configuration" section: "Please save the obtained refresh token in `data/token.json`" with example JSON `{ "refresh_token": "...." }`.
- `Dockerfile`: `ENV PIXIV_TOKEN_PATH=/data/token.json`.
- `src/main.ts:44`: `const tokenPath = process.env.PIXIV_TOKEN_PATH ?? 'data/token.json'` then `fs.readFileSync(tokenPath, 'utf8')`.
- `src/main.ts:96` reads `process.env.DELETE_BOOKMARK_FOR_DELETED_ITEMS`.
- `src/converters/base.ts:151` reads arbitrary env vars via `process.env[envVarName]`.

No `.env.example` or config template exists in the repo, so these patterns are inferred directly from README/Dockerfile/.gitignore/code.

## Related

https://github.com/book000/book000/issues/132